### PR TITLE
Update Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,6 @@
 #### HELPER METHODS
 def fail_if_no_supported_label_found
-  supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test", "next_release"]
+  supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test", "next_release", "dependencies"]
 
   supported_labels_in_pr = supported_types & github.pr_labels
   no_supported_label = supported_labels_in_pr.empty?
@@ -20,6 +20,7 @@ def fail_if_no_supported_label_found
   | *style* | Changes that don't affect the meaning of the code (white-space, formatting, missing semi-colons, etc |
   | *test* | Adding missing tests or correcting existing tests |
   | *next_release* | Preparing a new release |
+  | *dependencies* | Updating a dependency |
   MARKDOWN
   end
 end


### PR DESCRIPTION
Adds `dependencies` as a label. We already had it in purchases-hybrid-common https://github.com/RevenueCat/purchases-hybrid-common/commit/87fd5d9f7f5fcb4ceb54c5f92e5407c741e153f4 , but I just moved that repo to use this repo as the Dangerfile source so we need to add the `dependencies` here