### PR TITLE
Warn or fail a PR if increases total repo size in bytes by more than thresholds

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 #### GITHUB LABEL CHECK
 def fail_if_no_supported_label_found
   supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "RevenueCatUI", "style", "test", "next_release", "dependencies", "phc_dependencies"]
@@ -37,13 +39,12 @@ def check_pr_size_increase
   added_and_modified_files = git.added_files + git.modified_files
   total_size_increase = calculate_total_size_increase(added_and_modified_files)
 
-  message("Total size increase: #{total_size_increase} bytes")
   if total_size_increase > FAIL_SIZE_INCREASE
-    fail("This PR increases the repo size by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+    fail("This PR increases the size of the repo by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
   elsif total_size_increase > WARN_SIZE_INCREASE
-    warn("This PR increases the repo size by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+    warn("This PR increases the size of the repo by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
   else
-    message("Size check passed.")
+    message("Size increase: #{'%.2f' % toKB(total_size_increase)} KB")
   end
 end
 
@@ -57,7 +58,6 @@ def calculate_total_size_increase(files)
     file_size_in_branch = size_of_file(file)
     file_size_in_main = size_of_file_in_main(file)
     size_increase = file_size_in_branch - file_size_in_main
-      message("Size increase for #{file}: #{'%.2f' % toKB(size_increase)} KB")
     total_increase += size_increase if size_increase > 0
   end
   total_increase

--- a/Dangerfile
+++ b/Dangerfile
@@ -39,9 +39,11 @@ def check_pr_size_increase
 
   message("Total size increase: #{total_size_increase} bytes")
   if total_size_increase > FAIL_SIZE_INCREASE
-    fail("This PR increases the repo size by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+    fail("This PR increases the repo size by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB " \
+    "(increased by #{'%.2f' % toKB(total_size_increase)} KB).")
   elsif total_size_increase > WARN_SIZE_INCREASE
-    warn("This PR increases the repo size by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+    warn("This PR increases the repo size by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB "
+    "(increased by #{'%.2f' % toKB(total_size_increase)} KB).")
   else
     message("Size check passed.")
   end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,4 @@
-#### HELPER METHODS
+#### GITHUB LABEL CHECK
 def fail_if_no_supported_label_found
   supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "RevenueCatUI", "style", "test", "next_release", "dependencies", "phc_dependencies"]
 
@@ -27,5 +27,65 @@ def fail_if_no_supported_label_found
   end
 end
 
+#### PR SIZE INCREASE CHECK
+
+# Thresholds
+WARN_SIZE_INCREASE = 102400  # 100kb
+FAIL_SIZE_INCREASE = 256000  # 250kb
+
+def check_pr_size_increase
+  added_and_modified_files = git.added_files + git.modified_files
+  total_size_increase = calculate_total_size_increase(added_and_modified_files)
+
+  message("Total size increase: #{total_size_increase} bytes")
+  if total_size_increase > FAIL_SIZE_INCREASE
+    fail("This PR increases the repo size by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+  elsif total_size_increase > WARN_SIZE_INCREASE
+    warn("This PR increases the repo size by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+  else
+    message("Size check passed.")
+  end
+end
+
+def toKB(bytes)
+  bytes / 1024.0
+end
+
+def calculate_total_size_increase(files)
+  total_increase = 0
+  files.each do |file|
+    file_size_in_branch = size_of_file(file)
+    file_size_in_main = size_of_file_in_main(file)
+    size_increase = file_size_in_branch - file_size_in_main
+      message("Size increase for #{file}: #{'%.2f' % toKB(size_increase)} KB")
+    total_increase += size_increase if size_increase > 0
+  end
+  total_increase
+end
+
+# File size in the current branch
+def size_of_file(file_path)
+  if File.exists?(file_path)
+    File.size(file_path)
+  else
+    0
+  end
+end
+
+# File size in main branch
+def size_of_file_in_main(file)
+  escaped_file = Shellwords.shellescape(file)
+  if system("git cat-file -e main:#{escaped_file} 2> /dev/null")
+    `git show main:#{escaped_file} 2>/dev/null | wc -c`.to_i
+  else
+    0
+  end
+end
+
+#### ENTRY POINT
+
 # Fail when GitHub PR label is missing
 fail_if_no_supported_label_found
+
+# Fail/warn when PR size increase exceeds threshold
+check_pr_size_increase

--- a/Dangerfile
+++ b/Dangerfile
@@ -39,11 +39,9 @@ def check_pr_size_increase
 
   message("Total size increase: #{total_size_increase} bytes")
   if total_size_increase > FAIL_SIZE_INCREASE
-    fail("This PR increases the repo size by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB " \
-    "(increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+    fail("This PR increases the repo size by more than #{'%.2f' % toKB(FAIL_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
   elsif total_size_increase > WARN_SIZE_INCREASE
-    warn("This PR increases the repo size by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB "
-    "(increased by #{'%.2f' % toKB(total_size_increase)} KB).")
+    warn("This PR increases the repo size by more than #{'%.2f' % toKB(WARN_SIZE_INCREASE)} KB (increased by #{'%.2f' % toKB(total_size_increase)} KB).")
   else
     message("Size check passed.")
   end


### PR DESCRIPTION
We want to keep our main branch slim to ensure it is quick to clone, including by package managers. The changes here will warn/block PRs where the file size exceeds thresholds, currently set to warn at 100kb and fail at 250kb (up for discussion!).

This is an example of a PR that generates a warning:

<img width="935" alt="image" src="https://github.com/RevenueCat/Dangerfile/assets/109382862/a91e70f5-0d80-4b43-8373-2db1297bd576">
