### PR TITLE
Update Dangerfile for ruby 3.2.0 compatibility

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -78,7 +78,7 @@ end
 
 # File size in the current branch
 def size_of_file(file_path)
-  if File.exists?(file_path)
+  if File.exist?(file_path)
     File.size(file_path)
   else
     0


### PR DESCRIPTION
It seems like they removed `exists` in favor of `exist`. This should be backward compatible since ruby 3.1.x has both `exist` and `exists`.

Thank you for contributing to RevenueCat/Dangerfile. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.
