### PR TITLE
Add mapping for fail 

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -37,8 +37,10 @@ end
 # "trigger" => ["r1","r2"]       # multiple required labels
 REQUIRED_LABEL_MAP = {
   "feat:Customer Center" => "pr:RevenueCatUI",
+  "feat:Paywall Components" => "pr:RevenueCatUI",
+  "feat:PaywallV2" => "pr:RevenueCatUI",
+
   # Add more mappings here:
-  # "feat:Payments" => ["pr:RevenueCatUI", "pr:next_release"]
 }
 
 def fail_if_required_labels_missing

--- a/Dangerfile
+++ b/Dangerfile
@@ -126,11 +126,11 @@ end
 
 #### ENTRY POINT
 
-# Fail when required label mappings are missing
-fail_if_required_labels_missing
-
 # Fail when GitHub PR label is missing
 fail_if_no_supported_label_found
+
+# Fail when required label mappings are missing
+fail_if_required_labels_missing
 
 # Fail/warn when PR size increase exceeds threshold
 check_pr_size_increase


### PR DESCRIPTION
This PR adds a mapping section to prevent some labels to not be present (if others are present)

See https://github.com/RevenueCat/purchases-ios/pull/5479 for the failure

<img width="861" height="236" alt="Screenshot 2025-08-14 at 12 33 50" src="https://github.com/user-attachments/assets/09f77328-a8e3-4b31-a22b-617f63885b4c" />

