### PR TITLE
Indicate that `pr:changelog_ignore` label must be combined with another label

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -26,7 +26,7 @@ def fail_if_no_supported_label_found
   | *pr:next_release* | Preparing a new release |
   | *pr:dependencies* | Updating a dependency |
   | *pr:phc_dependencies* | Updating purchases-hybrid-common dependency |
-  | *pr:changelog_ignore* | The PR will not be included in the changelog. This label doesn't determine the type of bump of the version and can be combined with `pr:feat`, `pr:fix` or `pr:other`. |
+  | *pr:changelog_ignore* | The PR will not be included in the changelog. This label doesn't determine the type of bump of the version and must be combined with `pr:feat`, `pr:fix` or `pr:other`. |
     MARKDOWN
   end
 end


### PR DESCRIPTION
The current description for the `pr:changelog_ignore` label states that
> This label doesn't determine the type of bump of the version and **can** be combined with `pr:feat`, `pr:fix` or `pr:other`.

I propose to change `can` with `must` so that it's more explicit that the `pr:changelog_ignore` label is not enough by itself.